### PR TITLE
Update storybook dev port.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/esm/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6007",
     "build-storybook": "storybook build",
     "build": "rollup -c",
     "predeploy": "npm run build-storybook",


### PR DESCRIPTION
This PR updates the story book dev port to 6007. The reason for this change is, the `ui-layout-manager` uses port 6006. While developing, I use `npm link` to import the `sample-ui-component-library` into the `ui-layout-manager` and I have both storybook instances running at the same time. This change allows me to run both at the same time while developing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Storybook development server to use port 6007 instead of 6006.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->