### PR TITLE
Update the behavior of the viewer component to randomize tabs and active tab.

### DIFF
--- a/src/components/Viewer/MonacoInstance/MonacoInstance.jsx
+++ b/src/components/Viewer/MonacoInstance/MonacoInstance.jsx
@@ -32,7 +32,10 @@ export const MonacoInstance = ({editorContent}) => {
             theme="vs-dark"
             options={{
                 scrollBeyondLastLine:false,
-                fontSize:"12px"
+                fontSize:"12px",
+                minimap: {
+                    enabled: false  
+                }
             }}
         />
     );

--- a/src/components/Viewer/Tabs/Tabs.jsx
+++ b/src/components/Viewer/Tabs/Tabs.jsx
@@ -109,12 +109,12 @@ export const Tabs = ({files, selectFile, systemTree}) => {
 
     useEffect(() => {
         if (files && files.length > 0) {    
-            const numFiles = Math.floor(Math.random() * (files.length-1)) + 1;
-            const newFiles = files.splice(0, numFiles);
+            const numFiles = Math.floor(Math.random() * files.length) + 1;
+            const newFiles = files.slice(0, numFiles);
             setTabsList(newFiles);
-            const randomFileNumber = Math.floor(Math.random() * (newFiles.length-1)) + 1;
-            setActiveTab(newFiles[randomFileNumber].key);
-            selectFile(newFiles[randomFileNumber].key);
+            const randomFileIndex = Math.floor(Math.random() * newFiles.length);
+            setActiveTab(newFiles[randomFileIndex].key);
+            selectFile(newFiles[randomFileIndex].key);
         }
     }, [files]);
     

--- a/src/components/Viewer/Tabs/Tabs.jsx
+++ b/src/components/Viewer/Tabs/Tabs.jsx
@@ -109,9 +109,12 @@ export const Tabs = ({files, selectFile, systemTree}) => {
 
     useEffect(() => {
         if (files && files.length > 0) {    
-            setTabsList(files);
-            setActiveTab(files[0].key);
-            selectFile(files[0].key);
+            const numFiles = Math.floor(Math.random() * (files.length-1)) + 1;
+            const newFiles = files.splice(0, numFiles);
+            setTabsList(newFiles);
+            const randomFileNumber = Math.floor(Math.random() * (newFiles.length-1)) + 1;
+            setActiveTab(newFiles[randomFileNumber].key);
+            selectFile(newFiles[randomFileNumber].key);
         }
     }, [files]);
     

--- a/src/components/Viewer/Viewer.jsx
+++ b/src/components/Viewer/Viewer.jsx
@@ -67,11 +67,11 @@ export const Viewer = ({systemTree, onFileSelect}) => {
     }
     
     return (
-        <div className="viewerContainer d-flex flex-column">
-            <div>
+        <div className="viewerContainer">
+            <div className="tabContainer">
                 <Tabs files={files} selectFile={selectFile} systemTree={systemTree}/>
             </div>
-            <div className="d-flex flex-grow-1">
+            <div className="monacoContainer">
                 <MonacoInstance editorContent={editorContent}/>
             </div>
         </div>

--- a/src/components/Viewer/Viewer.scss
+++ b/src/components/Viewer/Viewer.scss
@@ -1,5 +1,25 @@
 .viewerContainer {
-    position: relative;
-    width: 100%;
-    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right:0;
+    overflow:hidden;
+}
+
+.tabContainer{
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 40px;
+    right:0;
+}
+
+.monacoContainer{
+    position: absolute;
+    top: 40px;
+    left: 0;
+    bottom: 0;
+    right:0;
+
 }


### PR DESCRIPTION
This PR makes minor changes to the behavior viewer component so that it is more useful as a demo component. It displays a random number of tabs and selects a random tab at startup. 

I also disabled the minimap because it flickers when resizing the container and when there are many editors, it is visually distracting. I plan to fix this problem by disabling the minimap when resizing the editor.

This PR also sets the size of the tab and editor containers in absolute terms so that the editor height matches the new container height when it is resized using the handle bars.

Note: This version of the viewer component is meant for demo purposes. I intend to rewrite it in a more modular way so that it exposes all the features like adding breakpoints, highlighting lines etc. I will design the component so it exposes the necessary features (tabs given a file list, breakpoints for file list, highlighting lines) and then the program logic will be built on top of this in the application that uses it.

## Validation Performed
- Verified that the component works in storybook as expected.
- Verified that the component renders as expected when imported into the ui-layout manager. I also verified that the editor height is set correctly when resizing the containers in the ui-layout-manager.

<img width="1919" height="951" alt="image" src="https://github.com/user-attachments/assets/5581fdc8-39fd-42dd-b4a1-d15c90cea0a3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration to hide the minimap in the code viewer for a cleaner interface.

* **Enhancements**
  * Tabs now display a random subset of files and randomly select an active tab, providing a varied initial view.
  * Updated the layout and styling of the viewer, introducing a new split between the tabs and code area for improved visual organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->