### PR TITLE
Add feature to disable/enable animation in FlowDiagram component.

### DIFF
--- a/src/components/FlowDiagram/FlowDiagram.jsx
+++ b/src/components/FlowDiagram/FlowDiagram.jsx
@@ -15,11 +15,11 @@ import { getLayoutInfoFromTree } from "./helper.js"
 const Flow = ({tree}) => {
   const { fitView } = useReactFlow();
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
-  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);  
 
   useEffect(() => {
     if (tree) {
-        const flowInfo = getLayoutInfoFromTree(tree.data);
+        const flowInfo = getLayoutInfoFromTree(tree.data, tree.animated);
         
         //direction: TB, BT, LR, or RL, where T = top, B = bottom, L = left, and R = right.
         const layouted = getLayoutedElements(

--- a/src/components/FlowDiagram/FlowDiagram.jsx
+++ b/src/components/FlowDiagram/FlowDiagram.jsx
@@ -19,7 +19,7 @@ const Flow = ({tree}) => {
 
   useEffect(() => {
     if (tree) {
-        const flowInfo = getLayoutInfoFromTree(tree.data, tree.animated);
+        const flowInfo = getLayoutInfoFromTree(tree.data, tree.animated ?? false);
         
         //direction: TB, BT, LR, or RL, where T = top, B = bottom, L = left, and R = right.
         const layouted = getLayoutedElements(

--- a/src/components/FlowDiagram/helper.js
+++ b/src/components/FlowDiagram/helper.js
@@ -16,7 +16,7 @@ const arrowStyle = {
  * Returns react flow nodes and edges from the given tree.
  * @param {Object} tree Layout tree object.
  * @param {boolean} animated Indicates if the edges should be animated.
- * @returns {Array} An array co
+ * @returns {Array} An object containing nodes and edges arrays.
  */
 export const getLayoutInfoFromTree = (tree, animated) => {
     const edges = [];

--- a/src/components/FlowDiagram/helper.js
+++ b/src/components/FlowDiagram/helper.js
@@ -14,10 +14,11 @@ const arrowStyle = {
 
 /**
  * Returns react flow nodes and edges from the given tree.
- * @param {Object} tree 
+ * @param {Object} tree Layout tree object.
+ * @param {boolean} animated Indicates if the edges should be animated.
  * @returns {Array} An array co
  */
-export const getLayoutInfoFromTree = (tree) => {
+export const getLayoutInfoFromTree = (tree, animated) => {
     const edges = [];
     const nodes = [];
     Object.keys(tree).forEach((branchName, index1) => {
@@ -41,7 +42,7 @@ export const getLayoutInfoFromTree = (tree) => {
                     id: prevNode.flowId + "-" + branchName + "-" + index + "-" + flowNode.flowId,
                     source: prevNode.flowId,
                     target: flowNode.flowId,
-                    animated: true,
+                    animated: animated,
                     markerEnd: marker,
                     style: arrowStyle
                 }


### PR DESCRIPTION
This PR adds a feature to enable/disable animation of the edges in the FlowDiagram component be setting the animated flag to be true or false in the tree information.

```
{
  "orientation": "TB",
  "data":{
        "branch1" : ["a","b","c","p"],
        "branch2" : ["a","b","d","x"],
        "branch3" : ["a","f","g","x"]
    }
  "animated": false
}
```

## Validation Performed

Loaded the FlowDiagram with animation disabled and verified that the animation was disabled.

<img width="1389" height="917" alt="image" src="https://github.com/user-attachments/assets/61eb41cb-3596-482b-982f-3f91d5e0c399" />

Loaded the FlowDiagram with animation enabled and verified that the animation was enabled.

<img width="1386" height="923" alt="image" src="https://github.com/user-attachments/assets/2c722987-1689-404d-9818-90322bd2ddb3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Flow diagrams now respect a configurable animation setting, so edges can be animated or static per diagram, giving clearer, more flexible visualization instead of always-on animation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->