### PR TITLE
Add component to render system diagram. 

### DIFF
--- a/src/components/SystemDiagramViewer/SystemDiagramViewer.jsx
+++ b/src/components/SystemDiagramViewer/SystemDiagramViewer.jsx
@@ -8,21 +8,27 @@ import {
   useReactFlow
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { drawioToReactFlow } from "./helper";
 
-const Flow = ({tree}) => {
+const Flow = ({diagram}) => {
   const { fitView } = useReactFlow();
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);  
 
   useEffect(() => {
-    if (tree) {
+    if (diagram) {
+      
+        console.log(diagram);
+        const nodes = drawioToReactFlow(diagram);
 
-        setNodes([]);
+        console.log(nodes);
+
+        setNodes([...nodes]);
         setEdges([]);
 
         fitView();
     }
-  }, [tree]);
+  }, [diagram]);
 
   return (
     <ReactFlow
@@ -39,15 +45,15 @@ const Flow = ({tree}) => {
 };
 
 export const SystemDiagramViewer = ({diagramJSON}) => {
-  const [tree, setTree] = useState();
+  const [diagram, setDiagram] = useState();
 
   useEffect(() => {
-    console.log(diagramJSON);
+    setDiagram(diagramJSON);
   }, [diagramJSON])
 
   return (
     <ReactFlowProvider>
-      <Flow tree={tree} />
+      <Flow diagram={diagram} />
     </ReactFlowProvider>
   );
 }

--- a/src/components/SystemDiagramViewer/SystemDiagramViewer.jsx
+++ b/src/components/SystemDiagramViewer/SystemDiagramViewer.jsx
@@ -19,7 +19,7 @@ const Flow = ({diagram}) => {
     if (diagram) {
         const layout = drawioToReactFlow(diagram);
 
-        console.log(layout);
+        console.log(diagram, layout);
 
         setNodes([...layout.nodes]);
         setEdges([...layout.edges]);

--- a/src/components/SystemDiagramViewer/SystemDiagramViewer.jsx
+++ b/src/components/SystemDiagramViewer/SystemDiagramViewer.jsx
@@ -17,14 +17,12 @@ const Flow = ({diagram}) => {
 
   useEffect(() => {
     if (diagram) {
-      
-        console.log(diagram);
-        const nodes = drawioToReactFlow(diagram);
+        const layout = drawioToReactFlow(diagram);
 
-        console.log(nodes);
+        console.log(layout);
 
-        setNodes([...nodes]);
-        setEdges([]);
+        setNodes([...layout.nodes]);
+        setEdges([...layout.edges]);
 
         fitView();
     }

--- a/src/components/SystemDiagramViewer/SystemDiagramViewer.jsx
+++ b/src/components/SystemDiagramViewer/SystemDiagramViewer.jsx
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  useNodesState,
+  useEdgesState,
+  Controls,
+  useReactFlow
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+const Flow = ({tree}) => {
+  const { fitView } = useReactFlow();
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);  
+
+  useEffect(() => {
+    if (tree) {
+
+        setNodes([]);
+        setEdges([]);
+
+        fitView();
+    }
+  }, [tree]);
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      colorMode={"dark"}
+      fitView
+    >
+      <Controls />
+    </ReactFlow>
+  );
+};
+
+export const SystemDiagramViewer = ({diagramJSON}) => {
+  const [tree, setTree] = useState();
+
+  useEffect(() => {
+    console.log(diagramJSON);
+  }, [diagramJSON])
+
+  return (
+    <ReactFlowProvider>
+      <Flow tree={tree} />
+    </ReactFlowProvider>
+  );
+}

--- a/src/components/SystemDiagramViewer/helper.js
+++ b/src/components/SystemDiagramViewer/helper.js
@@ -1,0 +1,53 @@
+export const drawioToReactFlow = (diagram) => {
+
+    const nodes = [];
+    const graphModel = diagram.mxGraphModel;
+    const diagramRoot = graphModel.root;
+
+    for (let i = 0; i < diagramRoot.length; i++) {
+        const elem = diagramRoot[i];
+        const isEdge = "mxCell@edge" in elem;
+
+        if (!isEdge && "mxCell" in elem ) {
+            const geo = elem.mxCell;
+            const width = geo["mxGeometry@width"];
+            const height = geo["mxGeometry@height"];
+            const x = geo["mxGeometry@x"];
+            const y = geo["mxGeometry@y"];
+
+            console.log(x, y, width, height);
+            const node = {
+                id: elem["mxCell@id"],
+                type: "input",
+                data: { label: 'Node 1' },
+                position: { x: x, y: y },
+            }
+            nodes.push(node);
+        }
+    }
+
+    return nodes;
+}
+
+/**
+ * {
+      id: '1',
+      type: 'input',
+      data: { label: 'Node 1' },
+      position: { x: 0, y: 25 },
+      sourcePosition: Position.Right,
+    },
+    {
+      id: '2',
+      type: 'custom',
+      data: {},
+      position: { x: 250, y: 50 },
+    },
+    {
+      id: '3',
+      type: 'input',
+      data: { label: 'Node 2' },
+      position: { x: 0, y: 100 },
+      sourcePosition: Position.Right,
+    },
+ */

--- a/src/components/SystemDiagramViewer/helper.js
+++ b/src/components/SystemDiagramViewer/helper.js
@@ -4,29 +4,29 @@ export const drawioToReactFlow = (diagram) => {
 
     const nodes = [];
     const edges = [];
-    const graphModel = diagram.mxGraphModel;
-    const diagramRoot = graphModel.root;
+    const graphModel = diagram.mxfile.diagram.mxGraphModel;
+    const diagramRoot = graphModel.root.mxCell;
 
     for (let i = 0; i < diagramRoot.length; i++) {
         const elem = diagramRoot[i];
-        const isEdge = "mxCell@edge" in elem;
+        const isEdge = "_edge" in elem;
 
-        if (!isEdge && "mxCell" in elem ) {
-            const geo = elem.mxCell;
-            const width = geo["mxGeometry@width"];
-            const height = geo["mxGeometry@height"];
-            const x = geo["mxGeometry@x"];
-            const y = geo["mxGeometry@y"];
+        if (!isEdge && "mxGeometry" in elem ) {
+            const geo = elem.mxGeometry;
+            const width = geo["_width"];
+            const height = geo["_height"];
+            const x = geo["_x"];
+            const y = geo["_y"];
 
             const node = {
-                id: elem["mxCell@id"],
+                id: elem["_id"],
                 data: { label: 'Node 1' },
                 position: { x: x, y: y },
             }
             nodes.push(node);
         } else if (isEdge) {
-            const source = elem["mxCell@source"];
-            const target = elem["mxCell@target"];
+            const source = elem["_source"];
+            const target = elem["_target"];
             const edge = {
                 id: i.toString(),
                 source: source,

--- a/src/components/SystemDiagramViewer/helper.js
+++ b/src/components/SystemDiagramViewer/helper.js
@@ -1,6 +1,9 @@
+import { string } from "prop-types";
+
 export const drawioToReactFlow = (diagram) => {
 
     const nodes = [];
+    const edges = [];
     const graphModel = diagram.mxGraphModel;
     const diagramRoot = graphModel.root;
 
@@ -15,21 +18,40 @@ export const drawioToReactFlow = (diagram) => {
             const x = geo["mxGeometry@x"];
             const y = geo["mxGeometry@y"];
 
-            console.log(x, y, width, height);
             const node = {
                 id: elem["mxCell@id"],
-                type: "input",
                 data: { label: 'Node 1' },
                 position: { x: x, y: y },
             }
             nodes.push(node);
+        } else if (isEdge) {
+            const source = elem["mxCell@source"];
+            const target = elem["mxCell@target"];
+            const edge = {
+                id: i.toString(),
+                source: source,
+                target: target
+            }
+            edges.push(edge);
         }
     }
 
-    return nodes;
+    return {
+        nodes: nodes,
+        edges: edges
+    }
 }
 
 /**
+ * 
+ * {
+    id: 'e1-3',
+    source: '1-1',
+    target: '1-3',
+    animated: true,
+    label: 'animated edge',
+  },
+ * 
  * {
       id: '1',
       type: 'input',

--- a/src/components/SystemDiagramViewer/index.js
+++ b/src/components/SystemDiagramViewer/index.js
@@ -1,0 +1,1 @@
+export * from "./SystemDiagramViewer.jsx"

--- a/src/stories/SystemDiagramViewer.scss
+++ b/src/stories/SystemDiagramViewer.scss
@@ -1,0 +1,7 @@
+.systemDiagramViewerWrapper{
+    position: absolute;
+    top:0;
+    bottom:0;
+    left:0;
+    right:0;
+}

--- a/src/stories/SystemDiagramViewer.stories.js
+++ b/src/stories/SystemDiagramViewer.stories.js
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { useArgs } from "@storybook/preview-api";
+import { SystemDiagramViewer } from "../components/SystemDiagramViewer/SystemDiagramViewer";
+
+import diagramJSON from "./data/diagram.json";
+
+import "./SystemDiagramViewer.scss"
+
+export default {
+    title: 'SystemDiagramViewer', 
+    component: SystemDiagramViewer,
+    argTypes: {}
+};
+
+const Template = (args) => {
+    const [, updateArgs] = useArgs();
+
+    useEffect(() => {
+    }, []);
+
+    return (
+        <div className="systemDiagramViewerWrapper">
+            <SystemDiagramViewer {...args} />
+        </div>
+    )
+}
+
+export const Default = Template.bind({})
+
+Default.args = {
+    diagramJSON: diagramJSON
+}

--- a/src/stories/data/diagram copy.json
+++ b/src/stories/data/diagram copy.json
@@ -1,0 +1,106 @@
+{
+  "mxGraphModel@dx": "1687",
+  "mxGraphModel@dy": "993",
+  "mxGraphModel@grid": "0",
+  "mxGraphModel@gridSize": "10",
+  "mxGraphModel@guides": "1",
+  "mxGraphModel@tooltips": "1",
+  "mxGraphModel@connect": "1",
+  "mxGraphModel@arrows": "1",
+  "mxGraphModel@fold": "1",
+  "mxGraphModel@page": "1",
+  "mxGraphModel@pageScale": "1",
+  "mxGraphModel@pageWidth": "1400",
+  "mxGraphModel@pageHeight": "850",
+  "mxGraphModel@math": "0",
+  "mxGraphModel@shadow": "0",
+  "mxGraphModel": {
+    "root": [
+      {
+        "mxCell@id": "0"
+      },
+      {
+        "mxCell@id": "1",
+        "mxCell@parent": "0"
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-4",
+        "mxCell@style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;",
+        "mxCell@edge": "1",
+        "mxCell@parent": "1",
+        "mxCell@source": "WcGXvPDrtN7Y4DXhmcHZ-1",
+        "mxCell@target": "WcGXvPDrtN7Y4DXhmcHZ-2",
+        "mxCell": {
+          "mxGeometry@relative": "1",
+          "mxGeometry@as": "geometry"
+        }
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-1",
+        "mxCell@value": "",
+        "mxCell@style": "rounded=0;whiteSpace=wrap;html=1;",
+        "mxCell@vertex": "1",
+        "mxCell@parent": "1",
+        "mxCell": {
+          "mxGeometry@x": "292",
+          "mxGeometry@y": "142",
+          "mxGeometry@width": "120",
+          "mxGeometry@height": "60",
+          "mxGeometry@as": "geometry"
+        }
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-5",
+        "mxCell@style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;",
+        "mxCell@edge": "1",
+        "mxCell@parent": "1",
+        "mxCell@source": "WcGXvPDrtN7Y4DXhmcHZ-2",
+        "mxCell@target": "WcGXvPDrtN7Y4DXhmcHZ-3",
+        "mxCell": {
+          "mxGeometry@relative": "1",
+          "mxGeometry@as": "geometry"
+        }
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-2",
+        "mxCell@value": "",
+        "mxCell@style": "rounded=0;whiteSpace=wrap;html=1;",
+        "mxCell@vertex": "1",
+        "mxCell@parent": "1",
+        "mxCell": {
+          "mxGeometry@x": "661",
+          "mxGeometry@y": "395",
+          "mxGeometry@width": "120",
+          "mxGeometry@height": "60",
+          "mxGeometry@as": "geometry"
+        }
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-6",
+        "mxCell@style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;",
+        "mxCell@edge": "1",
+        "mxCell@parent": "1",
+        "mxCell@source": "WcGXvPDrtN7Y4DXhmcHZ-3",
+        "mxCell@target": "WcGXvPDrtN7Y4DXhmcHZ-1",
+        "mxCell": {
+          "mxGeometry@relative": "1",
+          "mxGeometry@as": "geometry"
+        }
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-3",
+        "mxCell@value": "",
+        "mxCell@style": "rounded=0;whiteSpace=wrap;html=1;",
+        "mxCell@vertex": "1",
+        "mxCell@parent": "1",
+        "mxCell": {
+          "mxGeometry@x": "990",
+          "mxGeometry@y": "141",
+          "mxGeometry@width": "120",
+          "mxGeometry@height": "60",
+          "mxGeometry@as": "geometry"
+        }
+      }
+    ]
+  }
+}

--- a/src/stories/data/diagram.json
+++ b/src/stories/data/diagram.json
@@ -1,0 +1,106 @@
+{
+  "mxGraphModel@dx": "1687",
+  "mxGraphModel@dy": "993",
+  "mxGraphModel@grid": "0",
+  "mxGraphModel@gridSize": "10",
+  "mxGraphModel@guides": "1",
+  "mxGraphModel@tooltips": "1",
+  "mxGraphModel@connect": "1",
+  "mxGraphModel@arrows": "1",
+  "mxGraphModel@fold": "1",
+  "mxGraphModel@page": "1",
+  "mxGraphModel@pageScale": "1",
+  "mxGraphModel@pageWidth": "1400",
+  "mxGraphModel@pageHeight": "850",
+  "mxGraphModel@math": "0",
+  "mxGraphModel@shadow": "0",
+  "mxGraphModel": {
+    "root": [
+      {
+        "mxCell@id": "0"
+      },
+      {
+        "mxCell@id": "1",
+        "mxCell@parent": "0"
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-4",
+        "mxCell@style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;",
+        "mxCell@edge": "1",
+        "mxCell@parent": "1",
+        "mxCell@source": "WcGXvPDrtN7Y4DXhmcHZ-1",
+        "mxCell@target": "WcGXvPDrtN7Y4DXhmcHZ-2",
+        "mxCell": {
+          "mxGeometry@relative": "1",
+          "mxGeometry@as": "geometry"
+        }
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-1",
+        "mxCell@value": "",
+        "mxCell@style": "rounded=0;whiteSpace=wrap;html=1;",
+        "mxCell@vertex": "1",
+        "mxCell@parent": "1",
+        "mxCell": {
+          "mxGeometry@x": "292",
+          "mxGeometry@y": "142",
+          "mxGeometry@width": "120",
+          "mxGeometry@height": "60",
+          "mxGeometry@as": "geometry"
+        }
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-5",
+        "mxCell@style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;",
+        "mxCell@edge": "1",
+        "mxCell@parent": "1",
+        "mxCell@source": "WcGXvPDrtN7Y4DXhmcHZ-2",
+        "mxCell@target": "WcGXvPDrtN7Y4DXhmcHZ-3",
+        "mxCell": {
+          "mxGeometry@relative": "1",
+          "mxGeometry@as": "geometry"
+        }
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-2",
+        "mxCell@value": "",
+        "mxCell@style": "rounded=0;whiteSpace=wrap;html=1;",
+        "mxCell@vertex": "1",
+        "mxCell@parent": "1",
+        "mxCell": {
+          "mxGeometry@x": "661",
+          "mxGeometry@y": "395",
+          "mxGeometry@width": "120",
+          "mxGeometry@height": "60",
+          "mxGeometry@as": "geometry"
+        }
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-6",
+        "mxCell@style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;",
+        "mxCell@edge": "1",
+        "mxCell@parent": "1",
+        "mxCell@source": "WcGXvPDrtN7Y4DXhmcHZ-3",
+        "mxCell@target": "WcGXvPDrtN7Y4DXhmcHZ-1",
+        "mxCell": {
+          "mxGeometry@relative": "1",
+          "mxGeometry@as": "geometry"
+        }
+      },
+      {
+        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-3",
+        "mxCell@value": "",
+        "mxCell@style": "rounded=0;whiteSpace=wrap;html=1;",
+        "mxCell@vertex": "1",
+        "mxCell@parent": "1",
+        "mxCell": {
+          "mxGeometry@x": "990",
+          "mxGeometry@y": "141",
+          "mxGeometry@width": "120",
+          "mxGeometry@height": "60",
+          "mxGeometry@as": "geometry"
+        }
+      }
+    ]
+  }
+}

--- a/src/stories/data/diagram.json
+++ b/src/stories/data/diagram.json
@@ -1,106 +1,143 @@
 {
-  "mxGraphModel@dx": "1687",
-  "mxGraphModel@dy": "993",
-  "mxGraphModel@grid": "0",
-  "mxGraphModel@gridSize": "10",
-  "mxGraphModel@guides": "1",
-  "mxGraphModel@tooltips": "1",
-  "mxGraphModel@connect": "1",
-  "mxGraphModel@arrows": "1",
-  "mxGraphModel@fold": "1",
-  "mxGraphModel@page": "1",
-  "mxGraphModel@pageScale": "1",
-  "mxGraphModel@pageWidth": "1400",
-  "mxGraphModel@pageHeight": "850",
-  "mxGraphModel@math": "0",
-  "mxGraphModel@shadow": "0",
-  "mxGraphModel": {
-    "root": [
-      {
-        "mxCell@id": "0"
-      },
-      {
-        "mxCell@id": "1",
-        "mxCell@parent": "0"
-      },
-      {
-        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-4",
-        "mxCell@style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;",
-        "mxCell@edge": "1",
-        "mxCell@parent": "1",
-        "mxCell@source": "WcGXvPDrtN7Y4DXhmcHZ-1",
-        "mxCell@target": "WcGXvPDrtN7Y4DXhmcHZ-2",
-        "mxCell": {
-          "mxGeometry@relative": "1",
-          "mxGeometry@as": "geometry"
-        }
-      },
-      {
-        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-1",
-        "mxCell@value": "",
-        "mxCell@style": "rounded=0;whiteSpace=wrap;html=1;",
-        "mxCell@vertex": "1",
-        "mxCell@parent": "1",
-        "mxCell": {
-          "mxGeometry@x": "292",
-          "mxGeometry@y": "142",
-          "mxGeometry@width": "120",
-          "mxGeometry@height": "60",
-          "mxGeometry@as": "geometry"
-        }
-      },
-      {
-        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-5",
-        "mxCell@style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;",
-        "mxCell@edge": "1",
-        "mxCell@parent": "1",
-        "mxCell@source": "WcGXvPDrtN7Y4DXhmcHZ-2",
-        "mxCell@target": "WcGXvPDrtN7Y4DXhmcHZ-3",
-        "mxCell": {
-          "mxGeometry@relative": "1",
-          "mxGeometry@as": "geometry"
-        }
-      },
-      {
-        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-2",
-        "mxCell@value": "",
-        "mxCell@style": "rounded=0;whiteSpace=wrap;html=1;",
-        "mxCell@vertex": "1",
-        "mxCell@parent": "1",
-        "mxCell": {
-          "mxGeometry@x": "661",
-          "mxGeometry@y": "395",
-          "mxGeometry@width": "120",
-          "mxGeometry@height": "60",
-          "mxGeometry@as": "geometry"
-        }
-      },
-      {
-        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-6",
-        "mxCell@style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;",
-        "mxCell@edge": "1",
-        "mxCell@parent": "1",
-        "mxCell@source": "WcGXvPDrtN7Y4DXhmcHZ-3",
-        "mxCell@target": "WcGXvPDrtN7Y4DXhmcHZ-1",
-        "mxCell": {
-          "mxGeometry@relative": "1",
-          "mxGeometry@as": "geometry"
-        }
-      },
-      {
-        "mxCell@id": "WcGXvPDrtN7Y4DXhmcHZ-3",
-        "mxCell@value": "",
-        "mxCell@style": "rounded=0;whiteSpace=wrap;html=1;",
-        "mxCell@vertex": "1",
-        "mxCell@parent": "1",
-        "mxCell": {
-          "mxGeometry@x": "990",
-          "mxGeometry@y": "141",
-          "mxGeometry@width": "120",
-          "mxGeometry@height": "60",
-          "mxGeometry@as": "geometry"
-        }
-      }
-    ]
-  }
+	"mxfile": {
+		"diagram": {
+			"mxGraphModel": {
+				"root": {
+					"mxCell": [
+						{
+							"_id": "0"
+						},
+						{
+							"_id": "1",
+							"_parent": "0"
+						},
+						{
+							"mxGeometry": {
+								"_relative": "1",
+								"_as": "geometry"
+							},
+							"_id": "2",
+							"_style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;",
+							"_edge": "1",
+							"_source": "3",
+							"_target": "4",
+							"_parent": "1"
+						},
+						{
+							"mxGeometry": {
+								"_x": "509",
+								"_y": "135",
+								"_width": "120",
+								"_height": "60",
+								"_as": "geometry"
+							},
+							"_id": "3",
+							"_value": "",
+							"_style": "rounded=0;whiteSpace=wrap;html=1;",
+							"_vertex": "1",
+							"_parent": "1"
+						},
+						{
+							"mxGeometry": {
+								"_x": "661",
+								"_y": "395",
+								"_width": "120",
+								"_height": "60",
+								"_as": "geometry"
+							},
+							"_id": "4",
+							"_value": "",
+							"_style": "rounded=0;whiteSpace=wrap;html=1;",
+							"_vertex": "1",
+							"_parent": "1"
+						},
+						{
+							"mxGeometry": {
+								"_relative": "1",
+								"_as": "geometry"
+							},
+							"_id": "5",
+							"_style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;",
+							"_edge": "1",
+							"_source": "7",
+							"_target": "3",
+							"_parent": "1"
+						},
+						{
+							"mxGeometry": {
+								"_relative": "1",
+								"_as": "geometry"
+							},
+							"_id": "6",
+							"_style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;",
+							"_edge": "1",
+							"_source": "7",
+							"_target": "9",
+							"_parent": "1"
+						},
+						{
+							"mxGeometry": {
+								"_x": "990",
+								"_y": "141",
+								"_width": "120",
+								"_height": "60",
+								"_as": "geometry"
+							},
+							"_id": "7",
+							"_value": "",
+							"_style": "rounded=0;whiteSpace=wrap;html=1;",
+							"_vertex": "1",
+							"_parent": "1"
+						},
+						{
+							"mxGeometry": {
+								"_relative": "1",
+								"_as": "geometry"
+							},
+							"_id": "8",
+							"_style": "edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;",
+							"_edge": "1",
+							"_source": "9",
+							"_target": "4",
+							"_parent": "1"
+						},
+						{
+							"mxGeometry": {
+								"_x": "920",
+								"_y": "379",
+								"_width": "120",
+								"_height": "60",
+								"_as": "geometry"
+							},
+							"_id": "9",
+							"_value": "",
+							"_style": "rounded=0;whiteSpace=wrap;html=1;",
+							"_vertex": "1",
+							"_parent": "1"
+						}
+					]
+				},
+				"_dx": "1687",
+				"_dy": "993",
+				"_grid": "0",
+				"_gridSize": "10",
+				"_guides": "1",
+				"_tooltips": "1",
+				"_connect": "1",
+				"_arrows": "1",
+				"_fold": "1",
+				"_page": "1",
+				"_pageScale": "1",
+				"_pageWidth": "1400",
+				"_pageHeight": "850",
+				"_math": "0",
+				"_shadow": "0"
+			},
+			"_name": "Page-1",
+			"_id": "iL3vYbeKspdyjC68-Wn0"
+		},
+		"_host": "Electron",
+		"_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.7.17 Chrome/128.0.6613.36 Electron/32.0.1 Safari/537.36",
+		"_version": "24.7.17"
+	}
 }


### PR DESCRIPTION
This PR will add a component that can render a design diagram defined in draw.io for the trace viewer.

It does so in the following way:
- Convert draw.io file from XML to JSON and instrument it into the program.
- Use the JSON file to set the size of the canvas and position the nodes of the diagram (as described in the drawio file)
- Each node in the draw.io diagram will have the same ID as its counterpart in the <file_name>_design.json file that is instrumented into the program the realizes the design.
- This means that the abstractions in the semantic design graph will map to the design JSON file which will then directly map to the system diagram, allowing us to visualize the execution directly on the diagram

In the future, I won't use react flow, its unnecessary. I am just using it for convenience now but I will write my own library with the HTML5 canvas to implement this manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new SystemDiagramViewer component that enables interactive visualization and comprehensive exploration of system architecture diagrams with full support for displaying interconnected nodes, individual system components, and their complex relationships and interactions within the application.
  * Includes pre-configured sample diagram data optimized for testing, demonstration, and reference purposes during implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->