### PR TITLE
Editor: Fix style issues and add validation to tab.

### DIFF
--- a/src/components/Editor/Tabs/Tab/Tab.jsx
+++ b/src/components/Editor/Tabs/Tab/Tab.jsx
@@ -66,7 +66,7 @@ export const Tab = ({ id, parentId, info }) => {
         >
             <FileEarmark className="icon" style={{ pointerEvents: "none" }} />
             <span className="tab-name">{info.label}</span>
-            <XLg onMouseDown={clickClose} className="close-icon"/>
+            <span className="close-icon"><XLg onMouseDown={clickClose} /></span>
         </div>
     );
 }

--- a/src/components/Editor/Tabs/Tab/Tab.scss
+++ b/src/components/Editor/Tabs/Tab/Tab.scss
@@ -21,8 +21,7 @@
 
 .tab > .close-icon {
     margin-left:7px;
-    margin-right:7px;
     display:flex;
-    align-self: center;
-    width:10px;
+    align-items: center;
+    width:14px;
 }


### PR DESCRIPTION
In the previous PR #10, I forgot to fix the tab style and to add validation to the `add_tab `action in the reducer. I will fix those things in this PR.

Also, I think I should be spending some more time thinking about themes, styles etc., however, I am deferring that to later until I bring the engine into the work bench to build the design, map onto the implementation, instrument, execute etc. At that point, I will revisit the theme provider and rethink the styling of these components, for now, it is a fixed dark theme and it is not very customizable. 