### PR TITLE
fix: Use UID of parent group set by parent component.

### DIFF
--- a/src/components/Editor/Tabs/Tabs.jsx
+++ b/src/components/Editor/Tabs/Tabs.jsx
@@ -19,7 +19,7 @@ export const Tabs = () => {
     const [tabsList, setTabsList] = useState();
 
     useEffect(() => {
-        if (state.tabs?.length >= 0) {
+        if (state.tabs?.length >= 0 && state.parentTabGroupId != null) {
             drawTabs(state.tabs, state.parentTabGroupId);
         }
     }, [state.tabs, state.parentTabGroupId]);

--- a/src/components/Editor/Tabs/Tabs.jsx
+++ b/src/components/Editor/Tabs/Tabs.jsx
@@ -20,7 +20,7 @@ export const Tabs = () => {
 
     useEffect(() => {
         if (state.tabs?.length >= 0) {
-            drawTabs(state.tabs, state.uid);
+            drawTabs(state.tabs, state.parentTabGroupId);
         }
     }, [state.tabs, state.uid]);
 

--- a/src/components/Editor/Tabs/Tabs.jsx
+++ b/src/components/Editor/Tabs/Tabs.jsx
@@ -22,7 +22,7 @@ export const Tabs = () => {
         if (state.tabs?.length >= 0) {
             drawTabs(state.tabs, state.parentTabGroupId);
         }
-    }, [state.tabs, state.uid]);
+    }, [state.tabs, state.parentTabGroupId]);
 
     /**
      * Draw the tabs provided in the tabs info. This includes the gutters


### PR DESCRIPTION
This PR reverts a bug where the UID of the editors is not unique causing the drag and drop to not work as expected. In this PR, I am reverting the parent group ID of the tabs to be the value that is set by the consuming component. This will ensure that each editor is unique and that drag and drop will work as expected. 

Note: This isn't a permanent fix. I just didn't want to leave the library in a broken state, so I am reverting this functionality. I still think each component instance should set its own UID and the parent should read it. I will revisit this later and settle on a proper solution.
 
## Validation Performed

Imported library into work bench and verified that drag and drop functionality was restored. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected tab group identification so tabs and their gutters consistently use the parent group reference, preventing mis-association and ensuring stable updates when tab-group changes occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->