### PR TITLE
Update `BehavioralGraphBuilder` to use updated function call to get behavior name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-ui-component-library",
-  "version": "0.0.47-dev",
+  "version": "0.0.49-dev",
   "description": "A library which contains sample UI elements that can be used for populating layouts.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -46,7 +46,7 @@
     "@storybook/test": "^8.6.11",
     "@storybook/theming": "^8.6.11",
     "css-loader": "^7.1.2",
-    "dal-engine-core-js-lib-dev": "^0.0.4",
+    "dal-engine-core-js-lib-dev": "^0.0.15-dev",
     "gh-pages": "^6.3.0",
     "prop-types": "^15.8.1",
     "raw-loader": "^4.0.2",

--- a/src/components/BehavioralGraphBuilder/helper.js
+++ b/src/components/BehavioralGraphBuilder/helper.js
@@ -11,8 +11,8 @@ export const designToNodes = (engine) => {
     for (let i = 0; i < engine.graph.nodes.length; i++) {
         const node = engine.graph.nodes[i];
         nodes.push({
-            id: node.getBehavior().name,
-            text: node.getBehavior().name,
+            id: node.getBehavior().getName(),
+            text: node.getBehavior().getName(),
         });
     }
     
@@ -24,8 +24,8 @@ export const designToNodes = (engine) => {
 
         node.getGoToBehaviors().forEach((goTo) => {
             edges.push({
-                id: `${node.getBehavior().name}->${goTo}`,
-                from: node.getBehavior().name,
+                id: `${node.getBehavior().getName()}->${goTo}`,
+                from: node.getBehavior().getName(),
                 to: goTo,
             });
         });


### PR DESCRIPTION
I updated the engine library so the behavior name is accessed using a getter. This PR updates the helper script of the graph builder to access the name using the getter.

As I was doing this, it occurred to me that I shouldn't build the component this way, the component itself should just have rendering logic and the actual transformation into nodes and edges should be done externally. On the other hand, I am building this component specifically for the engine, so it is not unreasonable to do it this way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.0.49-dev
  * Updated dal-engine-core-js-lib-dev development dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->