### PR TITLE
Add v2 of file browser and editor components.

### DIFF
--- a/src/components/FileBrowserV2/FileBrowserContext.js
+++ b/src/components/FileBrowserV2/FileBrowserContext.js
@@ -1,0 +1,2 @@
+import { createContext } from "react";
+export const FileBrowserContext = createContext();

--- a/src/components/FileBrowserV2/FileBrowserReducer.js
+++ b/src/components/FileBrowserV2/FileBrowserReducer.js
@@ -1,0 +1,54 @@
+import { setDefaultCollapsed, collapseTree, flattenTree } from "./helper";
+
+export const initialState = {
+    uid: crypto.randomUUID(),
+    tree: {},
+    flattenedTree: [],
+    selectedNode: null,
+    collapsedTree: [],
+};
+
+export const fileBrowserReducer = (state, action) => {
+    switch (action.type) {
+        case "ADD_FILE_TREE": {
+            let flattenedTree = setDefaultCollapsed(flattenTree([...action.payload]));
+            const collapsedTree = collapseTree(flattenedTree);
+            return {
+                ...state,
+                tree: action.payload,
+                flattenedTree: flattenedTree,
+                collapsedTree: collapsedTree,
+            };
+        }
+
+        case "SELECT_NODE": {
+            const tree = state.flattenedTree.map((n) => {
+                if (n.uid === action.payload.uid) {
+                    return {
+                        ...n,
+                        selected: true,
+                        collapsed: !n.collapsed,
+                    };
+                }
+                return {
+                    ...n,
+                    selected: false,
+                };
+            });
+            return {
+                ...state,
+                flattenedTree: tree,
+                collapsedTree: collapseTree(tree),
+                selectedNode: action.payload,
+            };
+        }
+
+        case "RESET_STATE": {
+            return initialState;
+        }
+
+        default:{
+            return state;
+        }
+    }
+};

--- a/src/components/FileBrowserV2/FileBrowserV2.jsx
+++ b/src/components/FileBrowserV2/FileBrowserV2.jsx
@@ -1,0 +1,68 @@
+import {
+    forwardRef,
+    useReducer,
+    useMemo,
+    useCallback,
+    useContext,
+    useImperativeHandle,
+    useEffect,
+} from "react";
+import "./FileBrowserV2.scss";
+
+import { Tree } from "./Tree/Tree";
+
+import { FileBrowserContext } from "./FileBrowserContext";
+
+import { fileBrowserReducer, initialState } from "./FileBrowserReducer";
+
+/**
+ * Renders a file browser.
+ *
+ * @return {JSX}
+ */
+export const FileBrowserV2 = forwardRef(({onSelectFile}, ref) => {
+    const [state, dispatch] = useReducer(fileBrowserReducer, initialState);
+
+    const addFileTree = useCallback((tree) => {
+        dispatch({ type: "RESET_STATE"});
+        dispatch({ type: "ADD_FILE_TREE", payload: tree });
+    }, []);
+
+    useEffect(() => {
+        if (state.selectedNode && state.selectedNode.type === "file") {
+            onSelectFile(state.selectedNode);
+        }
+    }, [state.selectedNode]);
+
+    const selectNode = useCallback((node) => {
+        dispatch({ type: "SELECT_NODE", payload: node });
+    }, []);
+
+    const api = useMemo(() => {
+        return {
+            state,
+            addFileTree,
+            selectNode
+        };
+    }, [state, addFileTree, selectNode]);
+
+    useImperativeHandle(ref, () => api, [api]);
+
+    return (
+        <FileBrowserContext.Provider value={api}>
+            <div className="file-browser">
+                <Tree />
+            </div>
+        </FileBrowserContext.Provider>
+    );
+});
+
+FileBrowserV2.displayName = "FileBrowserV2";
+
+export function useFileBrowser() {
+    const ctx = useContext(FileBrowserContext);
+    if (!ctx) {
+        throw new Error("useFileBrowser must be used inside <FileBrowserV2>");
+    }
+    return ctx;
+}

--- a/src/components/FileBrowserV2/FileBrowserV2.scss
+++ b/src/components/FileBrowserV2/FileBrowserV2.scss
@@ -1,0 +1,11 @@
+.file-browser{
+    width: 100%;
+    height:100%;
+    color:white;
+    overflow-y: auto;
+    scrollbar-gutter: stable;
+    scrollbar-color: #47474766 #252526;
+    scrollbar-width: thin;
+    background-color: #1e1e1e;
+}
+

--- a/src/components/FileBrowserV2/Tree/Tree.jsx
+++ b/src/components/FileBrowserV2/Tree/Tree.jsx
@@ -1,0 +1,46 @@
+import {
+    useEffect,
+    useState
+} from "react";
+
+import { TreeNode } from "../TreeNode/TreeNode";
+
+import { useFileBrowser } from "../FileBrowserV2";
+
+import "./Tree.scss";
+
+/**
+ * Renders a file tree.
+ */
+export const Tree = ({}) => {
+    const [nodes, setNodes] = useState([]);
+    const {state} = useFileBrowser();
+
+    useEffect(() => {
+        drawTree(state.collapsedTree ?? []);
+    }, [state.collapsedTree]);
+
+    /**
+     * Draws the tree given the nodes and the collapsed state of each node.
+     */
+    const drawTree = (collapsedTree, parentId) => {
+        const rows = [];
+        collapsedTree.forEach((node) => {
+            rows.push(
+                <TreeNode
+                    key={parentId + "-" + node.uid}
+                    parentId={parentId}
+                    node={node}
+                    id={"tree-node-" + node.uid}
+                />,
+            );
+        });
+        setNodes(rows);
+    };
+
+    return (
+        <>
+            {nodes}
+        </>
+    )
+}

--- a/src/components/FileBrowserV2/TreeNode/TreeNode.jsx
+++ b/src/components/FileBrowserV2/TreeNode/TreeNode.jsx
@@ -1,0 +1,100 @@
+import { FileCode, ChevronRight, ChevronDown, Braces, FiletypeScss, FiletypeJs, FiletypePy } from "react-bootstrap-icons";
+import PropTypes from 'prop-types';
+import {
+    useDraggable
+} from "@dnd-kit/core";
+
+import { useFileBrowser } from "../FileBrowserV2";
+
+const INDENT_WIDTH = 20;
+const SELECTED_FILE_COLOR = "#00426b";
+
+import "./TreeNode.scss";
+import { useCallback } from "react";
+
+/**
+ * Renders a single node in the file tree.
+ */
+export const TreeNode = ({ id, parentId, node }) => {
+    const { attributes, listeners, setNodeRef, transform } = useDraggable(
+        { 
+            id,
+            data: {
+                type: "FileTreeNode",
+                parentId: parentId,
+                node: node,
+                preview: <TreeNodePreview node={node} />
+            }
+         }
+    );
+    const { selectNode } = useFileBrowser();
+
+    /**
+     * Gets the appropriate icon for the node based on its type and collapsed state.
+     * @returns <JSX>
+     */
+    const getCollapsedIcon = () => {
+        if (node.collapsed) {
+            return <ChevronRight />;
+        } else {
+            return <ChevronDown />;
+        }
+    }
+
+    /**
+     * Sets the background color of the row if the node is selected.
+     */
+    const getRowStyle = () => {
+        const style = {};
+        if (node.selected) {
+            style["backgroundColor"] = SELECTED_FILE_COLOR;
+        }
+        return style;
+    }
+
+    /**
+     * Get the file icon based on the extension.
+     * 
+     * TODO: This can be improved by having a mapping of extensions to icons and color.
+     */
+    const getFileIcon = () => {
+        const extension = node.name.split('.').pop();
+        switch (extension) {
+            case "js":
+                return <FiletypeJs color="#f1e05a" />;
+            case "json":
+                return <Braces color="#fffb00" />;
+            case "scss":
+                return <FiletypeScss color="#f12727" />;
+            case "py":
+                return <FiletypePy color="#686affbd" />;
+            default:
+                return <FileCode color="#ffffff" />;
+        }
+    }
+
+    const onSelectRow = useCallback(() => {
+        selectNode(node);
+    }, [selectNode]);
+
+    return (
+        <div className="file-node-row" ref={setNodeRef} {...listeners} {...attributes} 
+            style={getRowStyle()} onClick={onSelectRow}>
+            <div className="indent" style={{ width: node.level * INDENT_WIDTH + "px" }} />
+            {
+                node.type === "folder" ?
+                    <span className="folder-icon">{getCollapsedIcon()}</span> :
+                    <span className="file-icon">{getFileIcon()}</span>
+            }
+            <span className="file-name">{node.name}</span>
+        </div>
+    )
+}
+
+export const TreeNodePreview = ({node}) => {
+    return (
+         <div className="file-node-row" >
+            <span className="file-name">{node.name}</span>
+         </div>
+    );
+}

--- a/src/components/FileBrowserV2/TreeNode/TreeNode.scss
+++ b/src/components/FileBrowserV2/TreeNode/TreeNode.scss
@@ -1,0 +1,32 @@
+.file-node-row{
+    width:100%;
+    min-width: 200px;
+    display:flex;
+    font-size:13px;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    cursor: pointer;
+    height:28px;
+}
+
+.indent {
+    height:100%;
+    margin-left:10px;
+}
+
+.folder-icon {
+    display:flex;
+    margin-right: 5px;
+    align-items: center;
+}
+
+.file-icon {
+    display:flex;
+    margin-right: 5px;
+    align-items: center;
+}
+
+.file-name {
+    color: #DDD;
+    display:flex;
+    align-items: center;
+}

--- a/src/components/FileBrowserV2/helper.js
+++ b/src/components/FileBrowserV2/helper.js
@@ -1,0 +1,59 @@
+/**
+ * Sets the default collapsed state to false.
+ */
+export const setDefaultCollapsed = (tree) => {
+    tree.forEach((node) => {
+        node.collapsed = false;
+    });
+    return tree;
+}
+
+/**
+ * Given a file tree, it flattens the tree into a list of nodes with the level of each node in the tree.
+ * 
+ * @param {Array} tree - The file tree to flatten.
+ * @param {number} level - The current level of the tree (used for indentation).
+ * @return {Array} - The flattened tree with level information.
+ */
+export const flattenTree = (tree, level) => {
+    if (!level) {
+        level = 0;
+    }
+    let rows = [];
+    for (let i = 0; i < tree.length; i++) {
+        const node = tree[i];
+        node.level = level;
+        rows.push(node);
+        if (node?.children) {
+            rows = rows.concat(flattenTree(node.children, level + 1));
+        }
+    }
+    return rows;
+}
+
+/**
+ * Draws the tree given the nodes and the collapsed state of each node.
+ */
+export const collapseTree = (tree) => {
+    const rows = [];
+
+    let collapsing, collapseLevel;
+    for (let i = 0; i < tree.length; i++) {
+
+        if (collapsing) {
+            if (tree[i].level <= collapseLevel) {
+                collapsing = false;
+            } else {
+                continue;
+            }
+        }
+
+        if (tree[i].collapsed) {
+            collapsing = true;
+            collapseLevel = tree[i].level;
+        }
+
+        rows.push(tree[i]);
+    }
+    return rows;
+}

--- a/src/components/FileBrowserV2/index.js
+++ b/src/components/FileBrowserV2/index.js
@@ -1,0 +1,1 @@
+export * from "./FileBrowserV2.jsx"

--- a/src/stories/FileBrowserV2.stories.js
+++ b/src/stories/FileBrowserV2.stories.js
@@ -1,0 +1,137 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { FileBrowserV2 } from "../components/FileBrowserV2";
+import { useArgs } from "@storybook/preview-api";
+import { action } from "@storybook/addon-actions";
+import {
+    DndContext,
+    DragOverlay,
+    PointerSensor,
+    useSensor,
+    useSensors
+} from "@dnd-kit/core";
+
+import WorkspaceSampleTree from "./data/FileBrowser/workspace_sample.json"
+
+import "./FileBrowserV2Stories.scss"
+
+export default {
+    title: 'FileBrowserV2', 
+    component: FileBrowserV2,
+    argTypes: {}
+};
+
+/**
+ * Offset for the drag overlay.
+ * @returns 
+ */
+const offsetOverlay = ({ transform }) => {
+  return {
+    ...transform,
+    x: transform.x + 20,
+    y: transform.y + 20
+  };
+};
+
+
+const Template = (args) => {
+    const [, updateArgs] = useArgs();
+    const fileBrowserRef = useRef();
+    
+    const [dragPreviewLabel, setDragPreviewLabel] = useState(<></>);
+
+    const onSelectFile = (selectedFile) => {
+        action('Selected Node:')(selectedFile);
+    }
+
+    useEffect(() => {
+        updateArgs({onSelectFile : onSelectFile});
+    }, []);
+
+    useLayoutEffect(() => {
+        fileBrowserRef.current.addFileTree(args.tree);
+    }, []);
+
+
+    const [dragging, setDragging] = useState(false);
+  
+    /**
+     * Callback for when drag ends.
+     */
+    const handleDragEnd = (event) =>{
+        const { active, over } = event;
+        console.log("Drag Ended");
+        const rect = event.activatorEvent;
+
+        console.log(active, over);
+
+        if (over) {
+            console.log("Dragged item:", active.id);
+            console.log("Dropped on:", over.id);
+        } else {
+            console.log("Dropped outside any droppable");
+        }
+        setDragging(false);
+    }
+
+    /**
+     * Callback for when drag is started.
+     */
+    const onDragStart = (event) => {
+        console.log("Drag Started");
+        console.log(event.active.data);
+        setDragPreviewLabel(event.active.data.current.preview);
+        setDragging(true);
+    }
+
+    // Manually track the drag position.
+    const [pos, setPos] = useState({ x: 0, y: 0 });
+    useEffect(() => {
+        if (!dragging) return;
+
+        const handleMove = (e) => {
+            setPos({ x: e.clientX, y: e.clientY });
+        };
+
+        window.addEventListener("pointermove", handleMove);
+
+        return () => {
+            window.removeEventListener("pointermove", handleMove);
+        };
+    }, [dragging]);
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: {
+                distance: 8
+            }
+        })
+    );
+
+    return (
+        <DndContext sensors={sensors} onDragStart={onDragStart} onDragEnd={handleDragEnd}>
+            <div className="viewerStoryWrapper">
+                <div className="file-browser">
+                    <FileBrowserV2 ref={fileBrowserRef} {...args} />
+                </div>
+            </div>
+            {dragging && (
+                <div
+                    style={{
+                        position: "fixed",
+                        left: pos.x,
+                        top: pos.y,
+                        pointerEvents: "none",
+                        zIndex: 9999,
+                    }}>
+                    {dragPreviewLabel}
+                </div>
+            )}  
+        </DndContext>
+    )
+}
+
+export const SampleTree = Template.bind({});
+
+SampleTree.args = {
+    tree: WorkspaceSampleTree.tree
+}

--- a/src/stories/FileBrowserV2Stories.scss
+++ b/src/stories/FileBrowserV2Stories.scss
@@ -1,0 +1,10 @@
+.viewerStoryWrapper{
+    position: absolute;
+    top:0;
+    bottom:0;
+    left:0;
+    right:0;
+    display:flex;
+    align-items: center;
+    justify-content: center;
+}


### PR DESCRIPTION
This PR adds v2 of the file browser and editor components.

As I was getting ready to move onto the instrumentation, it became clear to me that the implementation module of the engine needed to be extended to standardize this process and make it easy to extend in the future. So I created a new hierarchy of classes which will allow the management of implementations, their files, the versions of the source for each file and the mapping for each version. This module was also extended to make it easy to add and remove mapping, essentially absorbing a lot of logic from the workbench front end, making the implementation much simpler. 

However, as I made this change, the format of the files and the API to work with the files changed. I decided that it would be best if I create v2 of these components that are meant to work with the new implementation module. At the end of this process, when the workbench is ready to instrument the code, it will simply ask the engine to export an instrumentation package that the runner will use.

So I will make these changes first and simplify things before I continue moving forward with the instrumentation. 

Note: It will only be called v2 for now, once I am happy with the changes, I will remove the old components and only maintain one. 

Note2: As part of these v2 changes, I am going to learn from some of my mistakes and make a clear distinction between the UI and the application. In my existing implementation of the editor, I was modifying engine files in the editor (updated content of the active tab), this is a bad way to do this and I am going to make sure that line is very clear in this implementation. You should be able to drop the editor into any new application and make it work with the applications logic.