### PR TITLE
add highlight behavior feature thorugh imperative api call

### DIFF
--- a/src/components/BehavioralGraphBuilder/BehavioralGraphBuilder.jsx
+++ b/src/components/BehavioralGraphBuilder/BehavioralGraphBuilder.jsx
@@ -13,6 +13,7 @@ import "./BehavioralGraphBuilder.scss";
  */
 export const BehavioralGraphBuilder = forwardRef(({connectBehaviors, deleteTransition, deleteBehavior, selectBehavior}, ref) => {
     const canvasRef = useRef();
+    const [selectedBehavior, setSelectedBehavior] = useState(null);
 
     // Resizer to set canvas size to match container
     // TODO: Issues with zooming and resizing, need to explore.
@@ -42,11 +43,18 @@ export const BehavioralGraphBuilder = forwardRef(({connectBehaviors, deleteTrans
         }
     }, [setNodes, setEdges]);
 
+
+    const highlightBehavior = useCallback((id) => {
+        // setSelectedBehavior(id);
+        setSelections(id?[id]:[]);
+    }, [setSelectedBehavior, setSelections]);
+
     const api = useMemo(() => {
         return {
-            updateEngine
+            updateEngine,
+            highlightBehavior
         };
-    }, [updateEngine]);
+    }, [updateEngine, highlightBehavior]);
     
     useImperativeHandle(ref, () => api, [api]);
 

--- a/src/stories/BehavioralGraphBuilder.stories.js
+++ b/src/stories/BehavioralGraphBuilder.stories.js
@@ -36,6 +36,8 @@ const Template = (args) => {
             if (tool === "add-node") {
                 engine.addNode("node-" + count++, []);
                 editorRef.current.updateEngine(engine);
+            } else if (tool === "select-node") {
+                editorRef.current.highlightBehavior("testBehavior");
             }
         },
         [activeTool, setActiveTool, engine],
@@ -57,7 +59,7 @@ const Template = (args) => {
                 engine.addNode("testBehavior", []);
                 engine.addNode("testBehavior2", []);
                 editorRef.current.updateEngine(engine);
-            }, 4000);
+            }, 1000);
             return () => clearTimeout(timerId);
         }
     }, [design, editorRef]);

--- a/src/stories/components/ToolBar/ToolBar.js
+++ b/src/stories/components/ToolBar/ToolBar.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 
 import {
+  Eye,
   PlusSquare,
   Floppy
 } from "react-bootstrap-icons";
@@ -27,6 +28,11 @@ export function ToolBar({ onSelectTool }) {
         <PlusSquare
           onClick={(e) => selectTool("add-node")}
           title="Add Node"
+          className="icon"
+        />
+        <Eye
+          onClick={(e) => selectTool("select-node")}
+          title="Select Node"
           className="icon"
         />
       </div>


### PR DESCRIPTION
As I was working on visualizing the design trace in the workbench for automated debugging, I needed a way to highlight the currently selected behavior. So I added this API call and I am going to modify the style of the highlight to not include a delete button. 

In the bigger picture, the idea is that the design trace has a series of steps and at each step a behavior is being exhibited. This corresponds to certain participants, their variable values, the semantic invariants which define their correctness and the corresponding implementation statement. Of course the entire trace will be automatically debugged by enforcing the invariants and then the user will be able to visit the relevant points in the trace. Anyway, this is probably not the right place to present this but the highlight feature of this PR is to satisfy this requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Select Node" button to the toolbar (marked with an eye icon) for highlighting and selecting specific behaviors in the graph visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->